### PR TITLE
Fix the bug for "bytes remove --end".

### DIFF
--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -106,6 +106,13 @@ impl Command for BytesRemove {
                 )),
             },
             Example {
+                description: "Remove find binary from end not found",
+                example: "0x[10 AA 10 BB CC AA 10] | bytes remove --end 0x[11]",
+                result: Some(Value::test_binary (
+                    vec![0x10, 0xAA, 0x10, 0xBB, 0xCC, 0xAA, 0x10],
+                )),
+            },
+            Example {
                 description: "Remove all occurrences of find binary in table",
                 example: "[[ColA ColB ColC]; [0x[11 12 13] 0x[14 15 16] 0x[17 18 19]]] | bytes remove 0x[11] ColA ColC",
                 result: Some(Value::test_list (

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -159,7 +159,7 @@ fn remove_impl(input: &[u8], arg: &Arguments, span: Span) -> Value {
         }
         // append the remaining thing to result, this can be happening when
         // we have something to remove and remove_all is False.
-        // check if the left is negative, if it is, we don't need to append anything.
+        // check if the left is positive, if it is not, we don't need to append anything.
         if left > 0 {
             let mut remain = input[..left as usize].iter().copied().rev().collect();
             result.append(&mut remain);

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -159,8 +159,11 @@ fn remove_impl(input: &[u8], arg: &Arguments, span: Span) -> Value {
         }
         // append the remaining thing to result, this can be happening when
         // we have something to remove and remove_all is False.
-        let mut remain = input[..left as usize].iter().copied().rev().collect();
-        result.append(&mut remain);
+        // check if the left is negative, if it is, we don't need to append anything.
+        if left > 0 {
+            let mut remain = input[..left as usize].iter().copied().rev().collect();
+            result.append(&mut remain);
+        }
         result = result.into_iter().rev().collect();
         Value::binary(result, span)
     } else {


### PR DESCRIPTION
This PR should close #11426 .

# Description
> ### Describe the bug
> When using the `--end` option of bytes remove, nushell panics if the provided bytes don't exist. This doesn't seem to affect `bytes remove` w/o flag or `bytes remove --all`.

# User-Facing Changes
Nushell doesn`t panic anymore.

# Tests + Formatting
Behavior before fixing the bug:
![nu-before changes](https://github.com/UPB-CS-OpenSourceUpstream/nushell/assets/119429832/f9c26d88-8962-4f38-a373-ba436a26ca7c)
Behavior after fixing the bug:
![nu- after changes](https://github.com/UPB-CS-OpenSourceUpstream/nushell/assets/119429832/0dd2b487-1696-45a6-9ea2-928cbd3a33a8)
