### PR TITLE
SOLVING TODO: determine if this is necessary or not, since this breaks `rm` o…

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -38,6 +38,9 @@ pub(crate) fn acquire_terminal(interactive: bool) {
             // TODO: determine if this is necessary or not, since this breaks `rm` on macOS
             // signal(Signal::SIGCHLD, SigHandler::SigIgn).expect("signal ignore");
 
+            #[cfg(not(target_os = "macos"))]
+            signal(Signal::SIGCHLD, SigHandler::SigIgn).expect("signal ignore");
+
             signal_hook::low_level::register(signal_hook::consts::SIGTERM, || {
                 // Safety: can only call async-signal-safe functions here
                 // restore_terminal, signal, and raise are all async-signal-safe


### PR DESCRIPTION
This PR solves: 
- the TODO in the `/crates/nu-test-support/src/macros.rs` file.
	Here, there was integrated an option to specify a custom plugin path in the 'nu_run_test' and `nu_with_plugin_run_test` functions. This allows testing with plugins without affecting the user's local environment, ensuring a more controlled and isolated testing setup.
	Specifically, a custom_plugin_path field was added to the `NuOpts` struct and utilized within the `nu_with_plugin_run_test` function. If a custom plugin path is provided in the options, it's set as an environment variable for the command that runs the test. This modification enhances the flexibility and robustness of the testing environment in the Nushell.

- the TODO in the `/src/terminal.rs` file.
	Here, the signal(`SIGCHLD`, `SigHandler::SigIgn`) call became conditional, by executing it only on non-macOS systems to avoid breaking the rm command on macOS.